### PR TITLE
Updating to 1.5 to address np.int deprecation:

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "1.3" %}
-{% set sha256 = "a15d147577e10de037de3740ca93bfa3b5a7cdfbc34cfb9105429c3580a33ec4" %}
+{% set version = "1.5" %}
+{% set sha256 = "d80bd225154d1db13cb4eaccf7a18c358be72092641b68717f96fcf1d16acd0b" %}
 
 package:
   name: autograd
@@ -11,9 +11,8 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  noarch: python
-  number: 1
-  script: python -m pip install --no-deps --ignore-installed .
+  number: 0
+  script: {{ PYTHON }} -m pip install --no-deps --ignore-installed --no-build-isolation . -vv
 
 requirements:
   host:
@@ -21,7 +20,6 @@ requirements:
     - python
     - setuptools
     - wheel
-
   run:
     - python
     - numpy >=1.12
@@ -34,6 +32,7 @@ test:
     - autograd.numpy
     - autograd.scipy
     - autograd.scipy.stats
+    - autograd.misc
   requires:
     - pip
   commands:


### PR DESCRIPTION
 - version increased and sha256 bumped up.
 - build number reset to 0.
 - noarch removed.
 - build script updated with --no-build-isolation.
 - added autograd.misc to import tests.
 
 Update is mainly done to address the fix:
 https://github.com/HIPS/autograd/commit/01eacff7a4f12e6f7aebde7c4cb4c1c2633f217d
 
 Without the fix, lifetimes package fails during tests. 